### PR TITLE
MySQLのデータをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docker/mysql/*
+backend/tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docker/mysql/*
 backend/tmp/*
+.DS_Store


### PR DESCRIPTION
### やったこと

- docker/mysql以下のファイルをgitignoreに追加し、コミット対象にならないようにした。
- ついでにbackend/tmpも不要なので、gitignoreに追加してコミット対象にならないようにした。

### 検証事項

- [ ] gitignoreにおいて、対象ディレクトリは正しく指定されているかどうか。