### PR TITLE
投稿詳細ページのUI作成

### DIFF
--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -1,13 +1,13 @@
 import { Routes, Route } from 'react-router-dom'
 
-import { HelloWorld } from '../features/helloworld'
 import { PostsRoute } from '../pages/posts/PostsRoute'
+import { PostDetailRoute } from '../pages/posts/detail/PostDetailRoute'
 
 export const AppRoute = () => {
   return (
     <Routes>
       <Route path="/" element={<PostsRoute />} />
-      <Route path="/posts" element={<HelloWorld />} />
+      <Route path="/posts/:id" element={<PostDetailRoute />} />
     </Routes>
   )
 }

--- a/frontend/src/pages/posts/detail/AttributeDisplay.tsx
+++ b/frontend/src/pages/posts/detail/AttributeDisplay.tsx
@@ -1,0 +1,16 @@
+import { Box, Text } from '@yamada-ui/react'
+type attributeDisplayProps = {
+  labelName: string
+  value: string
+}
+
+export const AttributeDisplay = ({ labelName, value }: attributeDisplayProps) => {
+  return (
+    <Text color="gray.200">
+      {labelName}
+      <Box as="span" color="black">
+        {value}
+      </Box>
+    </Text>
+  )
+}

--- a/frontend/src/pages/posts/detail/PostDetailRoute.tsx
+++ b/frontend/src/pages/posts/detail/PostDetailRoute.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { MOCK_POSTS, post } from '../../../shared/models'
 import dayjs from 'dayjs'
 import { AttributeDisplay } from './AttributeDisplay'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 
 export const PostDetailRoute = () => {
   const { id } = useParams<{ id: string }>()
@@ -22,6 +22,7 @@ export const PostDetailRoute = () => {
       </HStack>
       <Divider variant="solid" />
       <Text>{post.body}</Text>
+      <Link to="/">戻る</Link>
     </Container>
   )
 }

--- a/frontend/src/pages/posts/detail/PostDetailRoute.tsx
+++ b/frontend/src/pages/posts/detail/PostDetailRoute.tsx
@@ -1,12 +1,17 @@
-import { Container, Text, HStack, Heading } from '@yamada-ui/react'
+import { Container, Text, HStack, Heading, Divider } from '@yamada-ui/react'
 import { useState } from 'react'
 import { MOCK_POSTS, post } from '../../../shared/models'
 import dayjs from 'dayjs'
 import { AttributeDisplay } from './AttributeDisplay'
+import { useParams } from 'react-router-dom'
 
 export const PostDetailRoute = () => {
-  // API取得
-  const [post, setPost] = useState<post>(MOCK_POSTS[0])
+  const { id } = useParams<{ id: string }>()
+  const [post, setPost] = useState<post>(() => {
+    const foundPost = MOCK_POSTS.find((post) => post.id === id)
+    return foundPost || MOCK_POSTS[0]
+  })
+
   return (
     <Container>
       <Heading size="lg">{post.title}</Heading>
@@ -15,6 +20,7 @@ export const PostDetailRoute = () => {
         <AttributeDisplay labelName="更新日時：" value={dayjs(post.updatedAt).format('YYYY年M月D日 HH:mm:ss')} />
         <AttributeDisplay labelName="ユーザー名：" value={post.userName} />
       </HStack>
+      <Divider variant="solid" />
       <Text>{post.body}</Text>
     </Container>
   )

--- a/frontend/src/pages/posts/detail/PostDetailRoute.tsx
+++ b/frontend/src/pages/posts/detail/PostDetailRoute.tsx
@@ -1,0 +1,21 @@
+import { Container, Text, HStack, Heading } from '@yamada-ui/react'
+import { useState } from 'react'
+import { MOCK_POSTS, post } from '../../../shared/models'
+import dayjs from 'dayjs'
+import { AttributeDisplay } from './AttributeDisplay'
+
+export const PostDetailRoute = () => {
+  // API取得
+  const [post, setPost] = useState<post>(MOCK_POSTS[0])
+  return (
+    <Container>
+      <Heading size="lg">{post.title}</Heading>
+      <HStack>
+        <AttributeDisplay labelName="作成日時：" value={dayjs(post.createdAt).format('YYYY年M月D日 HH:mm:ss')} />
+        <AttributeDisplay labelName="更新日時：" value={dayjs(post.updatedAt).format('YYYY年M月D日 HH:mm:ss')} />
+        <AttributeDisplay labelName="ユーザー名：" value={post.userName} />
+      </HStack>
+      <Text>{post.body}</Text>
+    </Container>
+  )
+}

--- a/frontend/src/shared/models/post.ts
+++ b/frontend/src/shared/models/post.ts
@@ -19,281 +19,38 @@ export const MOCK_POSTS: Array<post> = [
     updatedAt: '2024-06-02T00:00:00+09:00'
   },
   {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
+    id: '1',
+    title: 'モックタイトル1',
+    body: 'こんにちは\nこんにちは',
     userId: 'mock-user-id1',
-    userName: 'Funobu',
+    userName: 'わだ',
     createdAt: '2024-06-02T00:00:00+09:00',
     updatedAt: '2024-06-02T00:00:00+09:00'
   },
   {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
+    id: '2',
+    title: 'モックタイトル2',
+    body: 'こんにちは\nこんにちは',
     userId: 'mock-user-id1',
-    userName: 'Funobu',
+    userName: 'わだ',
     createdAt: '2024-06-02T00:00:00+09:00',
     updatedAt: '2024-06-02T00:00:00+09:00'
   },
   {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
+    id: '3',
+    title: 'モックタイトル3',
+    body: 'こんにちは\nこんにちは',
     userId: 'mock-user-id1',
-    userName: 'Funobu',
+    userName: 'わだ',
     createdAt: '2024-06-02T00:00:00+09:00',
     updatedAt: '2024-06-02T00:00:00+09:00'
   },
   {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
+    id: '4',
+    title: 'モックタイトル4',
+    body: 'こんにちは\nこんにちは',
     userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
-    createdAt: '2024-06-02T00:00:00+09:00',
-    updatedAt: '2024-06-02T00:00:00+09:00'
-  },
-  {
-    id: 'mock-id',
-    title: 'モックタイトル',
-    body: 'hoge',
-    userId: 'mock-user-id1',
-    userName: 'Funobu',
+    userName: 'わだ',
     createdAt: '2024-06-02T00:00:00+09:00',
     updatedAt: '2024-06-02T00:00:00+09:00'
   }


### PR DESCRIPTION
## 概要
投稿一覧にある投稿に対する、詳細ページを作成する

## やったこと
詳細ページの作成
<img width="1840" alt="スクリーンショット 2024-05-28 13 31 57" src="https://github.com/givery-bootcamp/dena-2024-team6/assets/68636852/34d91cb2-c8ec-4cde-95fd-5e70010ff331">


## やってないこと
- API繋ぎ込み
- デザイン
  - 全体的なデザイン
  - 戻るボタンの位置調整等