### PR TITLE
誤ったHostnameの修正

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,7 +8,7 @@ import (
 var HostName = "127.0.0.1"
 var Port = 9000
 var CorsAllowOrigin = "http://localhost:3000"
-var DBHostName = "localhost"
+var DBHostName = "db"
 var DBPort = 3306
 var DBName = "training"
 


### PR DESCRIPTION
### 背景
`docker-compose up -d`ののちの`curl http://localhost:9000`でエラーが発生していた

### 変更点
- [x] `DBHostName`を`localhost`から`db`に修正

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->

### 実施したテスト
再度`curl http://localhost:9000`を行い`It works!`が出力されることを確認した
