### PR TITLE
feat(backend): サインインAPIの実装

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/gin-contrib/cors v1.7.1
 	github.com/gin-gonic/gin v1.9.1
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	gorm.io/driver/mysql v1.5.6
 	gorm.io/gorm v1.25.10
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -34,6 +34,8 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/backend/internal/controllers/signin_controller.go
+++ b/backend/internal/controllers/signin_controller.go
@@ -6,6 +6,7 @@ import (
 	"myapp/internal/usecases"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 type SigninParams struct {
@@ -19,7 +20,7 @@ func SigninController(ctx *gin.Context) {
 
 	var params SigninParams
 	if err := ctx.ShouldBindJSON(&params); err != nil {
-		handleError(ctx, 400, err)
+		handleError(ctx, 400, errors.New("invalid request"))
 		return
 	}
 
@@ -30,6 +31,10 @@ func SigninController(ctx *gin.Context) {
 
 	result, err := usecase.Execute(params.Username, params.Password)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			handleError(ctx, 400, errors.New("username or password is incorrect"))
+			return
+		}
 		handleError(ctx, 500, err)
 		return
 	}

--- a/backend/internal/controllers/signin_controller.go
+++ b/backend/internal/controllers/signin_controller.go
@@ -29,7 +29,7 @@ func SigninController(ctx *gin.Context) {
 		return
 	}
 
-	result, err := usecase.Execute(params.Username, params.Password)
+	result, token, err := usecase.Execute(params.Username, params.Password)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			handleError(ctx, 400, errors.New("username or password is incorrect"))
@@ -38,5 +38,8 @@ func SigninController(ctx *gin.Context) {
 		handleError(ctx, 500, err)
 		return
 	}
+	// 本番環境ではSecureをtrueにする
+	// 本番環境でlocalhostを実際のドメインに変更する
+	ctx.SetCookie("token", token.Raw, 3600*24, "/", "localhost", false, true)
 	ctx.JSON(200, result)
 }

--- a/backend/internal/controllers/signin_controller.go
+++ b/backend/internal/controllers/signin_controller.go
@@ -32,7 +32,7 @@ func SigninController(ctx *gin.Context) {
 	result, token, err := usecase.Execute(params.Username, params.Password)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			handleError(ctx, 400, errors.New("username or password is incorrect"))
+			handleError(ctx, 404, errors.New("username or password is incorrect"))
 			return
 		}
 		handleError(ctx, 500, err)

--- a/backend/internal/controllers/signin_controller.go
+++ b/backend/internal/controllers/signin_controller.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"errors"
+	"myapp/internal/repositories"
+	"myapp/internal/usecases"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SigninParams struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func SigninController(ctx *gin.Context) {
+	repository := repositories.NewSigninRepository(DB(ctx))
+	usecase := usecases.NewSigninUsecase(repository)
+
+	var params SigninParams
+	if err := ctx.ShouldBindJSON(&params); err != nil {
+		handleError(ctx, 400, err)
+		return
+	}
+
+	if params.Username == "" || params.Password == "" {
+		handleError(ctx, 400, errors.New("username and password are required"))
+		return
+	}
+
+	result, err := usecase.Execute(params.Username, params.Password)
+	if err != nil {
+		handleError(ctx, 500, err)
+		return
+	}
+	ctx.JSON(200, result)
+}

--- a/backend/internal/entities/user.go
+++ b/backend/internal/entities/user.go
@@ -1,0 +1,6 @@
+package entities
+
+type User struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+}

--- a/backend/internal/interfaces/signin_repository.go
+++ b/backend/internal/interfaces/signin_repository.go
@@ -1,5 +1,7 @@
 package interfaces
 
+import "myapp/internal/entities"
+
 type SigninRepository interface {
-	Signin(username string, password string) (string, error)
+	Signin(username string, password string) (*entities.User, error)
 }

--- a/backend/internal/interfaces/signin_repository.go
+++ b/backend/internal/interfaces/signin_repository.go
@@ -1,0 +1,5 @@
+package interfaces
+
+type SigninRepository interface {
+	Signin(username string, password string) (string, error)
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -13,4 +13,7 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostsController)
 	app.GET("/posts/:postid", controllers.PostDetailController)
+	app.POST("/signin", func(ctx *gin.Context) {
+		ctx.String(200, "Signin")
+	})
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -14,6 +14,18 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/posts", controllers.PostsController)
 	app.GET("/posts/:postid", controllers.PostDetailController)
 	app.POST("/signin", func(ctx *gin.Context) {
-		ctx.String(200, "Signin")
+		// Get two parameters from JSON: username (string) and password (string)
+
+		var json struct {
+			Username string `json:"username" binding:"required"`
+			Password string `json:"password" binding:"required"`
+		}
+
+		if err := ctx.ShouldBindJSON(&json); err != nil {
+			ctx.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx.JSON(200, gin.H{"username": json.Username, "password": json.Password})
 	})
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -13,19 +13,5 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostsController)
 	app.GET("/posts/:postid", controllers.PostDetailController)
-	app.POST("/signin", func(ctx *gin.Context) {
-		// Get two parameters from JSON: username (string) and password (string)
-
-		var json struct {
-			Username string `json:"username" binding:"required"`
-			Password string `json:"password" binding:"required"`
-		}
-
-		if err := ctx.ShouldBindJSON(&json); err != nil {
-			ctx.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		ctx.JSON(200, gin.H{"username": json.Username, "password": json.Password})
-	})
+	app.POST("/signin", controllers.SigninController)
 }

--- a/backend/internal/repositories/signin_repository.go
+++ b/backend/internal/repositories/signin_repository.go
@@ -26,7 +26,7 @@ func (r *SigninRepository) Signin(username string, password string) (*entities.U
 	err := r.Conn.Table("users").Select(`
 		id,
 		name
-	`).Where("name = ? AND password = ?", username, password).Scan(&user).Error
+	`).Where("name = ? AND password = ?", username, password).First(&user).Error
 
 	if err != nil {
 		return nil, err

--- a/backend/internal/repositories/signin_repository.go
+++ b/backend/internal/repositories/signin_repository.go
@@ -32,10 +32,8 @@ func (r *SigninRepository) Signin(username string, password string) (*entities.U
 		return nil, err
 	}
 
-	ent_user := &entities.User{
+	return &entities.User{
 		ID:       user.ID,
 		Username: user.Name,
-	}
-	return ent_user, nil
-
+	}, nil
 }

--- a/backend/internal/repositories/signin_repository.go
+++ b/backend/internal/repositories/signin_repository.go
@@ -1,9 +1,18 @@
 package repositories
 
-import "gorm.io/gorm"
+import (
+	"myapp/internal/entities"
+
+	"gorm.io/gorm"
+)
 
 type SigninRepository struct {
 	Conn *gorm.DB
+}
+
+type User struct {
+	ID   int
+	Name string
 }
 
 func NewSigninRepository(conn *gorm.DB) *SigninRepository {
@@ -12,6 +21,21 @@ func NewSigninRepository(conn *gorm.DB) *SigninRepository {
 	}
 }
 
-func (r *SigninRepository) Signin(username string, password string) (string, error) {
-	return "{\"foo\":\"token\"}", nil
+func (r *SigninRepository) Signin(username string, password string) (*entities.User, error) {
+	var user User
+	err := r.Conn.Table("users").Select(`
+		id,
+		name
+	`).Where("name = ? AND password = ?", username, password).Scan(&user).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	ent_user := &entities.User{
+		ID:       user.ID,
+		Username: user.Name,
+	}
+	return ent_user, nil
+
 }

--- a/backend/internal/repositories/signin_repository.go
+++ b/backend/internal/repositories/signin_repository.go
@@ -1,0 +1,17 @@
+package repositories
+
+import "gorm.io/gorm"
+
+type SigninRepository struct {
+	Conn *gorm.DB
+}
+
+func NewSigninRepository(conn *gorm.DB) *SigninRepository {
+	return &SigninRepository{
+		Conn: conn,
+	}
+}
+
+func (r *SigninRepository) Signin(username string, password string) (string, error) {
+	return "{\"foo\":\"token\"}", nil
+}

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -1,0 +1,17 @@
+package usecases
+
+import "myapp/internal/interfaces"
+
+type SigninUsecase struct {
+	repository interfaces.SigninRepository
+}
+
+func NewSigninUsecase(r interfaces.SigninRepository) *SigninUsecase {
+	return &SigninUsecase{
+		repository: r,
+	}
+}
+
+func (u *SigninUsecase) Execute(username string, password string) (string, error) {
+	return u.repository.Signin(username, password)
+}

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -3,6 +3,9 @@ package usecases
 import (
 	"myapp/internal/entities"
 	"myapp/internal/interfaces"
+	"time"
+
+	"github.com/golang-jwt/jwt"
 )
 
 type SigninUsecase struct {
@@ -15,6 +18,14 @@ func NewSigninUsecase(r interfaces.SigninRepository) *SigninUsecase {
 	}
 }
 
-func (u *SigninUsecase) Execute(username string, password string) (*entities.User, error) {
-	return u.repository.Signin(username, password)
+func (u *SigninUsecase) Execute(username string, password string) (*entities.User, *jwt.Token, error) {
+	result, err := u.repository.Signin(username, password)
+	if err != nil {
+		return nil, nil, err
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"ID":        result.ID,
+		"ExpiresAt": time.Now().Add(time.Hour * 24).Unix(),
+	})
+	return result, token, nil
 }

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -1,6 +1,9 @@
 package usecases
 
-import "myapp/internal/interfaces"
+import (
+	"myapp/internal/entities"
+	"myapp/internal/interfaces"
+)
 
 type SigninUsecase struct {
 	repository interfaces.SigninRepository
@@ -12,6 +15,6 @@ func NewSigninUsecase(r interfaces.SigninRepository) *SigninUsecase {
 	}
 }
 
-func (u *SigninUsecase) Execute(username string, password string) (string, error) {
+func (u *SigninUsecase) Execute(username string, password string) (*entities.User, error) {
 	return u.repository.Signin(username, password)
 }


### PR DESCRIPTION
### 背景
Fixes: #24

### 変更点
- [ ] `curl http://localhost:9000/signin -X POST -H "application/json" -d '{"username":"taro","password":"password"}' `でsigninできる
- [ ] cookieを設定

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->

### 実施したテスト
