### PR TITLE
投稿一覧ページののロジック実装

### DIFF
--- a/frontend/orval.config.ts
+++ b/frontend/orval.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
       schemas: 'src/api/model',
       client: 'react-query',
       clean: true,
-      mock: true
+      mock: true,
+      override: {
+        mutator: {
+          path: './src/shared/libs/axios.ts',
+          name: 'customInstance',
+        },
+      },
     },
     input: {
       target: '../docs/api.yaml'

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -15,46 +15,46 @@ import type {
   UseQueryOptions,
   UseQueryResult
 } from '@tanstack/react-query'
-import * as axios from 'axios';
-import type {
-  AxiosError,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios'
 import type {
   Post
 } from './model'
+import { customInstance } from '../shared/libs/axios';
 
+
+type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
 
 /**
  * @summary 投稿の一覧
  */
 export const getPosts = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<Post[]>> => {
     
-    return axios.default.get(
-      `/posts`,options
-    );
-  }
-
+ options?: SecondParameter<typeof customInstance>,signal?: AbortSignal
+) => {
+      
+      
+      return customInstance<Post[]>(
+      {url: `/posts`, method: 'GET', signal
+    },
+      options);
+    }
+  
 
 export const getGetPostsQueryKey = () => {
     return [`/posts`] as const;
     }
 
     
-export const getGetPostsQueryOptions = <TData = Awaited<ReturnType<typeof getPosts>>, TError = AxiosError<void>>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>, axios?: AxiosRequestConfig}
+export const getGetPostsQueryOptions = <TData = Awaited<ReturnType<typeof getPosts>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
 ) => {
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
   const queryKey =  queryOptions?.queryKey ?? getGetPostsQueryKey();
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPosts>>> = ({ signal }) => getPosts({ signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPosts>>> = ({ signal }) => getPosts(requestOptions, signal);
 
       
 
@@ -64,13 +64,13 @@ const {query: queryOptions, axios: axiosOptions} = options ?? {};
 }
 
 export type GetPostsQueryResult = NonNullable<Awaited<ReturnType<typeof getPosts>>>
-export type GetPostsQueryError = AxiosError<void>
+export type GetPostsQueryError = void
 
 /**
  * @summary 投稿の一覧
  */
-export const useGetPosts = <TData = Awaited<ReturnType<typeof getPosts>>, TError = AxiosError<void>>(
-  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>, axios?: AxiosRequestConfig}
+export const useGetPosts = <TData = Awaited<ReturnType<typeof getPosts>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPosts>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
@@ -90,30 +90,33 @@ export const useGetPosts = <TData = Awaited<ReturnType<typeof getPosts>>, TError
  * @summary 投稿の一覧
  */
 export const getPostsPostId = (
-    postId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<Post>> => {
-    
-    return axios.default.get(
-      `/posts/${postId}`,options
-    );
-  }
-
+    postId: number,
+ options?: SecondParameter<typeof customInstance>,signal?: AbortSignal
+) => {
+      
+      
+      return customInstance<Post>(
+      {url: `/posts/${postId}`, method: 'GET', signal
+    },
+      options);
+    }
+  
 
 export const getGetPostsPostIdQueryKey = (postId: number,) => {
     return [`/posts/${postId}`] as const;
     }
 
     
-export const getGetPostsPostIdQueryOptions = <TData = Awaited<ReturnType<typeof getPostsPostId>>, TError = AxiosError<void>>(postId: number, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getPostsPostId>>, TError, TData>, axios?: AxiosRequestConfig}
+export const getGetPostsPostIdQueryOptions = <TData = Awaited<ReturnType<typeof getPostsPostId>>, TError = void>(postId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostsPostId>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
 ) => {
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
   const queryKey =  queryOptions?.queryKey ?? getGetPostsPostIdQueryKey(postId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPostsPostId>>> = ({ signal }) => getPostsPostId(postId, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPostsPostId>>> = ({ signal }) => getPostsPostId(postId, requestOptions, signal);
 
       
 
@@ -123,13 +126,13 @@ const {query: queryOptions, axios: axiosOptions} = options ?? {};
 }
 
 export type GetPostsPostIdQueryResult = NonNullable<Awaited<ReturnType<typeof getPostsPostId>>>
-export type GetPostsPostIdQueryError = AxiosError<void>
+export type GetPostsPostIdQueryError = void
 
 /**
  * @summary 投稿の一覧
  */
-export const useGetPostsPostId = <TData = Awaited<ReturnType<typeof getPostsPostId>>, TError = AxiosError<void>>(
- postId: number, options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof getPostsPostId>>, TError, TData>, axios?: AxiosRequestConfig}
+export const useGetPostsPostId = <TData = Awaited<ReturnType<typeof getPostsPostId>>, TError = void>(
+ postId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostsPostId>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,14 +6,19 @@ import './main.scss'
 import App from './app/App'
 import { store } from './shared/store'
 import { UIProvider } from '@yamada-ui/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+const queryClient = new QueryClient()
+
 root.render(
   <BrowserRouter>
-    <UIProvider>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </UIProvider>
+    <QueryClientProvider client={queryClient}>
+      <UIProvider>
+        <Provider store={store}>
+          <App />
+        </Provider>
+      </UIProvider>
+    </QueryClientProvider>
   </BrowserRouter>
 )

--- a/frontend/src/pages/posts/PostsRoute.tsx
+++ b/frontend/src/pages/posts/PostsRoute.tsx
@@ -1,16 +1,37 @@
-import { Card, CardBody, CardHeader, Container, Text, HStack, Heading, CardFooter, VStack } from '@yamada-ui/react'
-import { useEffect, useState } from 'react'
-import { MOCK_POSTS, post } from '../../shared/models'
-import dayjs, { Dayjs } from 'dayjs'
+import {
+  Loading,
+  Card,
+  CardBody,
+  CardHeader,
+  Container,
+  Text,
+  HStack,
+  Heading,
+  CardFooter,
+  VStack,
+  Center
+} from '@yamada-ui/react'
+import dayjs from 'dayjs'
+import { useGetPosts } from '../../api/api'
 
 export const PostsRoute = () => {
   // API取得
-  const [posts, setPosts] = useState<Array<post>>(MOCK_POSTS)
+  const { data, isLoading, isError } = useGetPosts()
   return (
     <Container>
       <Heading size="lg">投稿一覧</Heading>
+      {isLoading && (
+        <Center>
+          <Loading variant="circles" size="6xl" color="cyan.500" />
+        </Center>
+      )}
+      {isError && (
+        <Center>
+          <Heading>エラーが発生しました</Heading>
+        </Center>
+      )}
       <VStack w="full">
-        {posts.map((post) => (
+        {data?.map((post) => (
           <Card key={post.id} variant="outline" w="full">
             <CardHeader>
               <Heading size="md">{post.title}</Heading>
@@ -21,8 +42,8 @@ export const PostsRoute = () => {
             </CardBody>
             <CardFooter>
               <HStack>
-                <Text>{post.userName}</Text>
-                <Text>更新日時： {dayjs(post.updatedAt).format('YYYY年M月D日 HH:mm:ss')}</Text>
+                <Text>{post.user_name}</Text>
+                <Text>更新日時： {dayjs(post.updated_at).format('YYYY年M月D日 HH:mm:ss')}</Text>
               </HStack>
             </CardFooter>
           </Card>

--- a/frontend/src/shared/libs/axios.ts
+++ b/frontend/src/shared/libs/axios.ts
@@ -1,0 +1,22 @@
+// custom-instance.ts
+
+import Axios, { AxiosRequestConfig } from 'axios'
+
+export const AXIOS_INSTANCE = Axios.create({ baseURL: import.meta.env.VITE_API_ENDPOINT_PATH }) // use your own URL here or environment variable
+
+// add a second `options` argument here if you want to pass extra options to each generated query
+export const customInstance = <T>(config: AxiosRequestConfig, options?: AxiosRequestConfig): Promise<T> => {
+  const source = Axios.CancelToken.source()
+  const promise = AXIOS_INSTANCE({
+    ...config,
+    ...options,
+    cancelToken: source.token
+  }).then(({ data }) => data)
+
+  // @ts-ignore
+  promise.cancel = () => {
+    source.cancel('Query was cancelled')
+  }
+
+  return promise
+}


### PR DESCRIPTION
Resolve #5 

### 背景
<!-- このPRが発生した背景情報 -->

元々投稿一覧のUIは完成していたが、APIからデータを取得せず、モックのデータを使っていた。
そこで、今回の実装では、Tanstack Queryを使ってAPIからデータを取得するようにした。

### 変更点
- [ ] Tanstack Queryの共通部分の設定を追加 (アクセス対象のAPIのURLを環境変数から取得など)
- [ ] 投稿一覧ページのAPI繋ぎこみ実装 & ローディングやエラー表示によるUX向上

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->

### 実施したテスト
