### PR TITLE
サインインユーザ取得APIの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docker/mysql/*
 backend/tmp/*
 .DS_Store
+cookies.txt

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,6 +11,7 @@ var CorsAllowOrigin = "http://localhost:3000"
 var DBHostName = "db"
 var DBPort = 3306
 var DBName = "training"
+var JwtKey = "my_secret_key"
 
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {
@@ -30,5 +31,8 @@ func init() {
 	}
 	if v := os.Getenv("DB_NAME"); v != "" {
 		DBName = v
+	}
+	if v := os.Getenv("JWT_KEY"); v != "" {
+		JwtKey = v
 	}
 }

--- a/backend/internal/controllers/signin_controller.go
+++ b/backend/internal/controllers/signin_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"myapp/internal/config"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 
@@ -38,7 +39,7 @@ func SigninController(ctx *gin.Context) {
 		handleError(ctx, 500, err)
 		return
 	}
-	jwtKey := []byte("my_secret_key")
+	jwtKey := []byte(config.JwtKey)
 	signedToken, err := token.SignedString(jwtKey)
 	if err != nil {
 		handleError(ctx, 500, err)

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -1,7 +1,50 @@
 package controllers
 
-import "github.com/gin-gonic/gin"
+import (
+	"errors"
+	"myapp/internal/repositories"
+	"myapp/internal/usecases"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+)
 
 func UserController(ctx *gin.Context) {
-	ctx.String(200, "User")
+	repository := repositories.NewUserRepository(DB(ctx))
+	usecase := usecases.NewUserUsecase(repository)
+
+	token, err := ctx.Cookie("token")
+	if err != nil {
+		handleError(ctx, 401, errors.New("unauthorized"))
+		return
+	}
+
+	secret := []byte("secret")
+	claims, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		return secret, nil
+	})
+	if err != nil {
+		handleError(ctx, 401, errors.New("unauthorized"))
+		return
+	}
+
+	claimsMap, ok := claims.Claims.(jwt.MapClaims)
+	if !ok {
+		handleError(ctx, 401, errors.New("unauthorized"))
+		return
+	}
+
+	userID, ok := claimsMap["ID"].(int)
+	if !ok {
+		handleError(ctx, 401, errors.New("unauthorized"))
+		return
+	}
+
+	result, err := usecase.Execute(userID)
+	if err != nil {
+		handleError(ctx, 500, err)
+		return
+	}
+
+	ctx.JSON(200, result)
 }

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"errors"
-	"fmt"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 
@@ -17,7 +16,6 @@ func UserController(ctx *gin.Context) {
 	token, err := ctx.Cookie("token")
 	// userがログインしていない場合
 	if err != nil {
-		fmt.Println(err)
 		handleError(ctx, 401, errors.New("unauthorized"))
 		return
 	}

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -1,0 +1,7 @@
+package controllers
+
+import "github.com/gin-gonic/gin"
+
+func UserController(ctx *gin.Context) {
+	ctx.String(200, "User")
+}

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -2,8 +2,10 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
+	"reflect"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt"
@@ -15,32 +17,33 @@ func UserController(ctx *gin.Context) {
 
 	token, err := ctx.Cookie("token")
 	if err != nil {
-		handleError(ctx, 401, errors.New("unauthorized"))
+		fmt.Println(err)
+		handleError(ctx, 401, errors.New("unauthorized1"))
 		return
 	}
 
-	secret := []byte("secret")
+	secret := []byte("my_secret_key")
 	claims, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
 		return secret, nil
 	})
 	if err != nil {
-		handleError(ctx, 401, errors.New("unauthorized"))
+		handleError(ctx, 401, errors.New("unauthorized2"))
 		return
 	}
 
 	claimsMap, ok := claims.Claims.(jwt.MapClaims)
 	if !ok {
-		handleError(ctx, 401, errors.New("unauthorized"))
+		handleError(ctx, 401, errors.New("unauthorized3"))
 		return
 	}
 
-	userID, ok := claimsMap["ID"].(int)
+	userID, ok := claimsMap["ID"].(float64)
 	if !ok {
-		handleError(ctx, 401, errors.New("unauthorized"))
+		fmt.Println(reflect.TypeOf(claimsMap["ID"]))
+		handleError(ctx, 401, errors.New("unauthorized4"))
 		return
 	}
-
-	result, err := usecase.Execute(userID)
+	result, err := usecase.Execute(int(userID))
 	if err != nil {
 		handleError(ctx, 500, err)
 		return

--- a/backend/internal/entities/user.go
+++ b/backend/internal/entities/user.go
@@ -1,0 +1,6 @@
+package entities
+
+type User struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+}

--- a/backend/internal/interfaces/user_repository.go
+++ b/backend/internal/interfaces/user_repository.go
@@ -1,0 +1,9 @@
+package interfaces
+
+import (
+	"myapp/internal/entities"
+)
+
+type UserRepository interface {
+	Get() (*entities.User, error)
+}

--- a/backend/internal/interfaces/user_repository.go
+++ b/backend/internal/interfaces/user_repository.go
@@ -5,5 +5,5 @@ import (
 )
 
 type UserRepository interface {
-	Get() (*entities.User, error)
+	Get(id int) (*entities.User, error)
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -13,4 +13,7 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostsController)
 	app.GET("/posts/:postid", controllers.PostDetailController)
+	app.GET("/user", func(ctx *gin.Context) {
+		ctx.String(200, "User")
+	})
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -13,7 +13,5 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostsController)
 	app.GET("/posts/:postid", controllers.PostDetailController)
-	app.GET("/user", func(ctx *gin.Context) {
-		ctx.String(200, "User")
-	})
+	app.GET("/user", controllers.UserController)
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -10,13 +10,14 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/", func(ctx *gin.Context) {
 		ctx.String(200, "It works")
 	})
-
+	authRequeried := app.Group("/")
+	authRequeried.Use(SigninCheck())
 	app.GET("/hello", controllers.HelloWorld)
 
-	app.GET("/posts", controllers.PostsController)
-	app.GET("/posts/:postid", controllers.PostDetailController)
+	authRequeried.GET("/posts", controllers.PostsController)
+	authRequeried.GET("/posts/:postid", controllers.PostDetailController)
 
 	app.POST("/signin", controllers.SigninController)
 
-	app.GET("/user", controllers.UserController)
+	authRequeried.GET("/user", controllers.UserController)
 }

--- a/backend/internal/middleware/signin_check.go
+++ b/backend/internal/middleware/signin_check.go
@@ -8,6 +8,11 @@ import (
 	"gorm.io/gorm"
 )
 
+type User struct {
+	ID   int
+	Name string
+}
+
 func SigninCheck() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		token, err := ctx.Cookie("token")
@@ -51,7 +56,9 @@ func SigninCheck() gin.HandlerFunc {
 			ctx.AbortWithError(500, errors.New("db type error"))
 			return
 		}
-		err = db.Table("users").First(&struct{}{}, "id = ?", int(userID)).Error
+		// ユーザーが存在するか確認
+		var user User
+		err = db.Table("users").First(&user, "id = ?", int(userID)).Error
 		if err != nil {
 			ctx.AbortWithError(404, errors.New("user not found"))
 			return

--- a/backend/internal/middleware/signin_check.go
+++ b/backend/internal/middleware/signin_check.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+	"gorm.io/gorm"
+)
+
+func SigninCheck() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		token, err := ctx.Cookie("token")
+		// userがログインしていない場合
+		if err != nil {
+			ctx.AbortWithError(401, errors.New("unauthorized"))
+			return
+		}
+
+		secret := []byte("my_secret_key")
+		claims, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+			return secret, nil
+		})
+		// tokenが不正な場合
+		if err != nil {
+			ctx.AbortWithError(400, errors.New("invalid token"))
+			return
+		}
+
+		claimsMap, ok := claims.Claims.(jwt.MapClaims)
+		// claimsがMapClaims型でない場合
+		if !ok {
+			ctx.AbortWithError(500, errors.New("claimsMap type error"))
+			return
+		}
+
+		userID, ok := claimsMap["ID"].(float64)
+		// IDがfloat64型でない場合
+		if !ok {
+			ctx.AbortWithError(500, errors.New("userID type error"))
+			return
+		}
+
+		dbCtx, ok := ctx.Get("db")
+		if !ok {
+			ctx.AbortWithError(500, errors.New("db not found"))
+			return
+		}
+		db, ok := dbCtx.(*gorm.DB)
+		if !ok {
+			ctx.AbortWithError(500, errors.New("db type error"))
+			return
+		}
+		err = db.Table("users").First(&struct{}{}, "id = ?", int(userID)).Error
+		if err != nil {
+			ctx.AbortWithError(404, errors.New("user not found"))
+			return
+		}
+		ctx.Next()
+	}
+}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -1,0 +1,24 @@
+package repositories
+
+import (
+	"myapp/internal/entities"
+
+	"gorm.io/gorm"
+)
+
+type UserRepository struct {
+	Conn *gorm.DB
+}
+
+func NewUserRepository(conn *gorm.DB) *UserRepository {
+	return &UserRepository{
+		Conn: conn,
+	}
+}
+
+func (r *UserRepository) Get(userID int) (*entities.User, error) {
+	return &entities.User{
+		ID:       42,
+		Username: "Yakisoba Taro",
+	}, nil
+}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -16,7 +16,7 @@ func NewUserRepository(conn *gorm.DB) *UserRepository {
 	}
 }
 
-func (r *UserRepository) Get(userID int) (*entities.User, error) {
+func (r *UserRepository) Get() (*entities.User, error) {
 	return &entities.User{
 		ID:       42,
 		Username: "Yakisoba Taro",

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -16,9 +16,19 @@ func NewUserRepository(conn *gorm.DB) *UserRepository {
 	}
 }
 
-func (r *UserRepository) Get() (*entities.User, error) {
+func (r *UserRepository) Get(id int) (*entities.User, error) {
+	var user User
+	err := r.Conn.Table("users").Select(`
+		id,
+		name
+	`).Where("id = ?", id).First(&user).Error
+
+	if err != nil {
+		return nil, err
+	}
+
 	return &entities.User{
-		ID:       42,
-		Username: "Yakisoba Taro",
+		ID:       user.ID,
+		Username: user.Name,
 	}, nil
 }

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -1,0 +1,20 @@
+package usecases
+
+import (
+	"myapp/internal/entities"
+	"myapp/internal/interfaces"
+)
+
+type UserUsecase struct {
+	repository interfaces.UserRepository
+}
+
+func NewUserUsecase(r interfaces.UserRepository) *UserUsecase {
+	return &UserUsecase{
+		repository: r,
+	}
+}
+
+func (u *UserUsecase) Execute() (*entities.User, error) {
+	return u.repository.Get()
+}

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -15,6 +15,6 @@ func NewUserUsecase(r interfaces.UserRepository) *UserUsecase {
 	}
 }
 
-func (u *UserUsecase) Execute() (*entities.User, error) {
-	return u.repository.Get()
+func (u *UserUsecase) Execute(id int) (*entities.User, error) {
+	return u.repository.Get(id)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"myapp/internal/config"
 	"myapp/internal/external"
 	"myapp/internal/middleware"
+
+	"github.com/gin-gonic/gin"
 )
 
 func main() {


### PR DESCRIPTION
Closes: #22
### 背景
サインインユーザを取得したい

### 変更点
- [ ] user controlerを追加
- [ ] signin checkのmiddlewareを追加
- [ ] `curl http://localhost:9000/users -b "token=signinで作成したtoken`でログインユーザーを確認できること

### 変更についての説明
一部のリクエスト（投稿一覧・投稿詳細・ログインユーザーの取得）の前にログインの確認を行う
`/user`エンドポイントで、ログインしているユーザーのentitiesを返す


### 実施したテスト
なし