### PR TITLE
認証・認可周りのOpenAPI定義 & コード自動生成

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -48,6 +48,29 @@ components:
         - user_id
         - user_name
         - created_at
+    LoginRequest:
+      description: ログインのリクエストモデル
+      type: object
+      properties:
+        user_name:
+          type: string
+          example: Funobu
+        password:
+          type: string
+          example: hogehoge
+      required:
+        - user_name
+        - password
+    User:
+      properties:
+        user_id:
+          type: integer
+          example: 1
+        user_name:
+          type: string
+          example: "Funobu"
+
+
 
 paths:
   /posts:
@@ -90,3 +113,38 @@ paths:
           description: Not Found
         "500":
           description: Internal Server Error
+  /signin:
+    post:
+      summary: ログイン
+      requestBody:
+        description: ログインするためのリクエスト
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+              example:
+                user_name: "Funobu"
+                password: "hogehoge"
+      responses:
+        "200":
+          description: ログイン成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+  /signout:
+    post:
+      summary: ログアウト
+      responses:
+        "200":
+          description: ログアウト成功
+  /user:
+    get:
+      summary: 現在ログインしているユーザを取得
+      responses:
+        "200":
+          description: ユーザ取得成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"

--- a/frontend/src/api/api.msw.ts
+++ b/frontend/src/api/api.msw.ts
@@ -15,12 +15,17 @@ import {
   http
 } from 'msw'
 import type {
-  Post
+  Post,
+  User
 } from './model'
 
 export const getGetPostsResponseMock = (): Post[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.helpers.arrayElement([faker.word.sample(), undefined]), created_at: `${faker.date.past().toISOString().split('.')[0]}Z`, id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), updated_at: faker.helpers.arrayElement([`${faker.date.past().toISOString().split('.')[0]}Z`, undefined]), user_id: faker.number.int({min: undefined, max: undefined}), user_name: faker.word.sample()})))
 
 export const getGetPostsPostIdResponseMock = (overrideResponse: Partial< Post > = {}): Post => ({body: faker.helpers.arrayElement([faker.word.sample(), undefined]), created_at: `${faker.date.past().toISOString().split('.')[0]}Z`, id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), updated_at: faker.helpers.arrayElement([`${faker.date.past().toISOString().split('.')[0]}Z`, undefined]), user_id: faker.number.int({min: undefined, max: undefined}), user_name: faker.word.sample(), ...overrideResponse})
+
+export const getPostSigninResponseMock = (overrideResponse: Partial< User > = {}): User => ({user_id: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), user_name: faker.helpers.arrayElement([faker.word.sample(), undefined]), ...overrideResponse})
+
+export const getGetUserResponseMock = (overrideResponse: Partial< User > = {}): User => ({user_id: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), user_name: faker.helpers.arrayElement([faker.word.sample(), undefined]), ...overrideResponse})
 
 
 export const getGetPostsMockHandler = (overrideResponse?: Post[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Post[])) => {
@@ -54,7 +59,56 @@ export const getGetPostsPostIdMockHandler = (overrideResponse?: Post | ((info: P
     )
   })
 }
+
+export const getPostSigninMockHandler = (overrideResponse?: User | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => User)) => {
+  return http.post('*/signin', async (info) => {
+    await delay(1000);
+    return new HttpResponse(JSON.stringify(overrideResponse !== undefined 
+            ? (typeof overrideResponse === "function" ? overrideResponse(info) : overrideResponse) 
+            : getPostSigninResponseMock()),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
+    )
+  })
+}
+
+export const getPostSignoutMockHandler = () => {
+  return http.post('*/signout', async () => {
+    await delay(1000);
+    return new HttpResponse(null,
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
+    )
+  })
+}
+
+export const getGetUserMockHandler = (overrideResponse?: User | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => User)) => {
+  return http.get('*/user', async (info) => {
+    await delay(1000);
+    return new HttpResponse(JSON.stringify(overrideResponse !== undefined 
+            ? (typeof overrideResponse === "function" ? overrideResponse(info) : overrideResponse) 
+            : getGetUserResponseMock()),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
+    )
+  })
+}
 export const getWebAPIMock = () => [
   getGetPostsMockHandler(),
-  getGetPostsPostIdMockHandler()
+  getGetPostsPostIdMockHandler(),
+  getPostSigninMockHandler(),
+  getPostSignoutMockHandler(),
+  getGetUserMockHandler()
 ]

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7,16 +7,22 @@
  * OpenAPI spec version: 1.0.0
  */
 import {
+  useMutation,
   useQuery
 } from '@tanstack/react-query'
 import type {
+  MutationFunction,
   QueryFunction,
   QueryKey,
+  UseMutationOptions,
+  UseMutationResult,
   UseQueryOptions,
   UseQueryResult
 } from '@tanstack/react-query'
 import type {
-  Post
+  LoginRequest,
+  Post,
+  User
 } from './model'
 import { customInstance } from '../shared/libs/axios';
 
@@ -137,6 +143,182 @@ export const useGetPostsPostId = <TData = Awaited<ReturnType<typeof getPostsPost
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
   const queryOptions = getGetPostsPostIdQueryOptions(postId,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+/**
+ * @summary ログイン
+ */
+export const postSignin = (
+    loginRequest: LoginRequest,
+ options?: SecondParameter<typeof customInstance>,) => {
+      
+      
+      return customInstance<User>(
+      {url: `/signin`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: loginRequest
+    },
+      options);
+    }
+  
+
+
+export const getPostSigninMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postSignin>>, TError,{data: LoginRequest}, TContext>, request?: SecondParameter<typeof customInstance>}
+): UseMutationOptions<Awaited<ReturnType<typeof postSignin>>, TError,{data: LoginRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postSignin>>, {data: LoginRequest}> = (props) => {
+          const {data} = props ?? {};
+
+          return  postSignin(data,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostSigninMutationResult = NonNullable<Awaited<ReturnType<typeof postSignin>>>
+    export type PostSigninMutationBody = LoginRequest
+    export type PostSigninMutationError = unknown
+
+    /**
+ * @summary ログイン
+ */
+export const usePostSignin = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postSignin>>, TError,{data: LoginRequest}, TContext>, request?: SecondParameter<typeof customInstance>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postSignin>>,
+        TError,
+        {data: LoginRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostSigninMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    
+/**
+ * @summary ログアウト
+ */
+export const postSignout = (
+    
+ options?: SecondParameter<typeof customInstance>,) => {
+      
+      
+      return customInstance<void>(
+      {url: `/signout`, method: 'POST'
+    },
+      options);
+    }
+  
+
+
+export const getPostSignoutMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postSignout>>, TError,void, TContext>, request?: SecondParameter<typeof customInstance>}
+): UseMutationOptions<Awaited<ReturnType<typeof postSignout>>, TError,void, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postSignout>>, void> = () => {
+          
+
+          return  postSignout(requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostSignoutMutationResult = NonNullable<Awaited<ReturnType<typeof postSignout>>>
+    
+    export type PostSignoutMutationError = unknown
+
+    /**
+ * @summary ログアウト
+ */
+export const usePostSignout = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postSignout>>, TError,void, TContext>, request?: SecondParameter<typeof customInstance>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postSignout>>,
+        TError,
+        void,
+        TContext
+      > => {
+
+      const mutationOptions = getPostSignoutMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    
+/**
+ * @summary 現在ログインしているユーザを取得
+ */
+export const getUser = (
+    
+ options?: SecondParameter<typeof customInstance>,signal?: AbortSignal
+) => {
+      
+      
+      return customInstance<User>(
+      {url: `/user`, method: 'GET', signal
+    },
+      options);
+    }
+  
+
+export const getGetUserQueryKey = () => {
+    return [`/user`] as const;
+    }
+
+    
+export const getGetUserQueryOptions = <TData = Awaited<ReturnType<typeof getUser>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
+) => {
+
+const {query: queryOptions, request: requestOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getGetUserQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUser>>> = ({ signal }) => getUser(requestOptions, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetUserQueryResult = NonNullable<Awaited<ReturnType<typeof getUser>>>
+export type GetUserQueryError = unknown
+
+/**
+ * @summary 現在ログインしているユーザを取得
+ */
+export const useGetUser = <TData = Awaited<ReturnType<typeof getUser>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData>>, request?: SecondParameter<typeof customInstance>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetUserQueryOptions(options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/frontend/src/api/model/loginRequest.ts
+++ b/frontend/src/api/model/loginRequest.ts
@@ -7,6 +7,10 @@
  * OpenAPI spec version: 1.0.0
  */
 
-export * from './loginRequest';
-export * from './post';
-export * from './user';
+/**
+ * ログインのリクエストモデル
+ */
+export interface LoginRequest {
+  password: string;
+  user_name: string;
+}

--- a/frontend/src/api/model/user.ts
+++ b/frontend/src/api/model/user.ts
@@ -7,6 +7,7 @@
  * OpenAPI spec version: 1.0.0
  */
 
-export * from './loginRequest';
-export * from './post';
-export * from './user';
+export interface User {
+  user_id?: number;
+  user_name?: string;
+}

--- a/frontend/src/shared/libs/axios.ts
+++ b/frontend/src/shared/libs/axios.ts
@@ -2,7 +2,10 @@
 
 import Axios, { AxiosRequestConfig } from 'axios'
 
-export const AXIOS_INSTANCE = Axios.create({ baseURL: import.meta.env.VITE_API_ENDPOINT_PATH }) // use your own URL here or environment variable
+export const AXIOS_INSTANCE = Axios.create({ 
+  baseURL: import.meta.env.VITE_API_ENDPOINT_PATH,
+  withCredentials: true
+ }) // use your own URL here or environment variable
 
 // add a second `options` argument here if you want to pass extra options to each generated query
 export const customInstance = <T>(config: AxiosRequestConfig, options?: AxiosRequestConfig): Promise<T> => {


### PR DESCRIPTION
### 背景
<!-- このPRが発生した背景情報 -->

### 変更点
- [ ] docs/api.yamlのOpenAPI定義に `/signin`, `/signout`, `/user`を定義した。
- [ ] Orvalを使ってフロントエンド側のAPIアクセスコードを生成した
- [ ] APIリクエスト送信時にCookieを送るように変更

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->

### 実施したテスト
