### PR TITLE
投稿更新APIの実装

### DIFF
--- a/backend/internal/controllers/update_post_controller.go
+++ b/backend/internal/controllers/update_post_controller.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"errors"
+	"myapp/internal/repositories"
+	"myapp/internal/usecases"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+func UpdatePostController(ctx *gin.Context) {
+	repository := repositories.NewPostsRepository(DB(ctx))
+	usecase := usecases.NewUpdatePostUsecase(repository)
+
+	postID, err := strconv.Atoi(ctx.Param("postid"))
+	if err != nil {
+		handleError(ctx, 400, err)
+		return
+	}
+
+	var params PostParams
+	if err := ctx.ShouldBindJSON(&params); err != nil {
+		handleError(ctx, 400, errors.New("invalid request"))
+		return
+	}
+
+	if params.Title == "" || params.Body == "" {
+		handleError(ctx, 400, errors.New("title and body are required"))
+		return
+	}
+
+	if len(params.Title) > 100 {
+		handleError(ctx, 400, errors.New("title must be less than 100 characters"))
+		return
+	}
+
+	rawUserID, ok := ctx.Get("userID")
+	if !ok {
+		handleError(ctx, 500, errors.New("userID not found"))
+		return
+	}
+
+	userID, ok := rawUserID.(int)
+	if !ok {
+		handleError(ctx, 500, errors.New("userID is invalid"))
+		return
+	}
+
+	post, err := usecase.Execute(userID, postID, params.Title, params.Body)
+	if err != nil {
+		handleError(ctx, 500, err)
+		return
+	}
+
+	ctx.JSON(200, post)
+}

--- a/backend/internal/interfaces/posts_repository.go
+++ b/backend/internal/interfaces/posts_repository.go
@@ -8,4 +8,5 @@ type PostsRepository interface {
 	List() ([]*entities.Post, error)
 	Get(postID int) (*entities.Post, error)
 	Create(userID int, title string, body string) (*entities.Post, error)
+	Update(userID int, postID int, title string, body string) (*entities.Post, error)
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -22,4 +22,5 @@ func SetupRoutes(app *gin.Engine) {
 	authRequeried.GET("/user", controllers.UserController)
 
 	authRequeried.POST("/posts", controllers.PostController)
+	authRequeried.PUT("/posts/:postid", controllers.UpdatePostController)
 }

--- a/backend/internal/repositories/posts_repository.go
+++ b/backend/internal/repositories/posts_repository.go
@@ -95,6 +95,35 @@ func (r *PostsRepository) Create(userID int, title string, body string) (*entiti
 	return r.Get(post.ID)
 }
 
+func (r *PostsRepository) Update(userID int, postID int, title string, body string) (*entities.Post, error) {
+	oldPost, err := r.Get(postID)
+	if err != nil {
+		return nil, err
+	}
+	if oldPost == nil {
+		return nil, errors.New("not found")
+	}
+	if oldPost.UserId != userID {
+		return nil, errors.New("unauthorized")
+	}
+
+	type PostPut struct {
+		Title string
+		Body  string
+	}
+
+	post := PostPut{
+		Title: title,
+		Body:  body,
+	}
+
+	err = r.Conn.Table("posts").Where("id = ?", postID).Updates(&post).Error
+	if err != nil {
+		return nil, err
+	}
+	return r.Get(postID)
+}
+
 func convertPostRepositoryModelToEntity(v *Post) *entities.Post {
 	return &entities.Post{
 		ID:        v.ID,

--- a/backend/internal/usecases/updete_post_usecase.go
+++ b/backend/internal/usecases/updete_post_usecase.go
@@ -1,0 +1,20 @@
+package usecases
+
+import (
+	"myapp/internal/entities"
+	"myapp/internal/interfaces"
+)
+
+type UpdatePostUsecase struct {
+	repository interfaces.PostsRepository
+}
+
+func NewUpdatePostUsecase(r interfaces.PostsRepository) *UpdatePostUsecase {
+	return &UpdatePostUsecase{
+		repository: r,
+	}
+}
+
+func (u *UpdatePostUsecase) Execute(userID int, postID int, title string, body string) (*entities.Post, error) {
+	return u.repository.Update(userID, postID, title, body)
+}


### PR DESCRIPTION
### 背景
<!-- このPRが発生した背景情報 -->
Close #54
### 変更点
- [ ] 投稿を更新する

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->
- [ ] `curl -X POST http://localhost:9000/signin -H "application/json" -d '{"username":"hanako","password":"PASSWORD"}' -c cookies.txt` でサインインした後、`curl -X PUT http://localhost:9000/posts/1 -i -d '{"title":"1","body":"body1"}' -b cookies.txt`したら更新できない
- [ ] `curl -X POST http://localhost:9000/signin -H "application/json" -d '{"username":"taro","password":"password"}' -c cookies.txt` でサインインした後、`curl -X PUT http://localhost:9000/posts/1 -i -d '{"title":"1","body":"body1"}' -b cookies.txt`したら正常に更新される
- [ ] ↑の後、`curl -X GET http://localhost:9000/posts/1 -i -b cookies.txt` で更新されたpostを表示できる

### 実施したテスト
