### PR TITLE
本番環境でタイムゾーンが見つからない不具合を修正

### DIFF
--- a/backend/infrastructure/store/store.go
+++ b/backend/infrastructure/store/store.go
@@ -11,11 +11,6 @@ import (
 )
 
 func NewStore(i *do.Injector) (*sqlx.DB, error) {
-	jst, err := time.LoadLocation("Asia/Tokyo")
-	if err != nil {
-		return nil, err
-	}
-
 	dsn := mysql.Config{
 		DBName:    config.DBName,
 		User:      "root",
@@ -23,7 +18,7 @@ func NewStore(i *do.Injector) (*sqlx.DB, error) {
 		Net:       "tcp",
 		ParseTime: true,
 		Collation: "utf8mb4_unicode_ci",
-		Loc:       jst,
+		Loc:       time.Local,
 	}
 
 	return sqlx.Open("mysql", dsn.FormatDSN())


### PR DESCRIPTION
### 背景
<!-- このPRが発生した背景情報 -->

### 変更点
- [ ] DBでのタイムゾーンの扱いにおいて 元々Asia/Tokyoを指定していたが、見つからないためLocalに変えた

### 変更についての説明
<!-- コードにコメントできるものはその方法で -->

### 実施したテスト
